### PR TITLE
Version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 20.11.2021
+### Changed
+- Bugfix: `_registerAdsPort` caused unhandled exception if using manually given AmsNetID.
+- NOTE: Updated version to 1.0.0 but everything is backwards compatible
+
 ## [0.2.2] - 16.01.2021
 ### Changed
 - Minor changes to console warning messages

--- a/README.md
+++ b/README.md
@@ -10,15 +10,6 @@ TwinCAT ADS server for Node.js (unofficial). Listens for incoming ADS protocol c
 If you need an ADS client for reading/writing PLC values, see my other project [ads-client](https://github.com/jisotalo/ads-client).
 
 
-# Project status
-
-Currently in testing. Should work OK.
-
-
-# NOTE
-
-This is my first project with Typescript, so it probably includes lot's of things to be done differently.
-
 # Table of contents
 - [Installing and configuration](#installing-and-configuration)
 - [Available ADS commands](#available-ads-commands)

--- a/src/ads-server.ts
+++ b/src/ads-server.ts
@@ -885,12 +885,15 @@ function _registerAdsPort(this: Server): Promise<AmsTcpPacket> {
     if (this.settings.localAmsNetId && this.settings.localAdsPort) {
       debug(`_registerAdsPort(): Local AmsNetId and ADS port manually given so using ${this.settings.localAmsNetId}:${this.settings.localAdsPort}`)
     
-      const res = {} as AmsTcpPacket
-
-      res.amsTcp.data = {
-        localAmsNetId: this.settings.localAmsNetId,
-          localAdsPort: this.settings.localAdsPort
-      }
+      const res = {
+        amsTcp: {
+          data: {
+            localAmsNetId: this.settings.localAmsNetId,
+            localAdsPort: this.settings.localAdsPort
+          }
+        }
+      } as AmsTcpPacket
+      
       return resolve(res)
     }
 


### PR DESCRIPTION
## [1.0.0] - 20.11.2021
### Changed
- Bugfix: `_registerAdsPort` caused unhandled exception if using manually given AmsNetID.
- NOTE: Updated version to 1.0.0 but everything is backwards compatible
