### PR TITLE
Version 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 13.09.2021
+- Bug fix: Connecting to local router failed with ECONNREFUSED error on Node.js version 17 and newer
+  - See [https://github.com/nodejs/node/issues/40702](https://github.com/nodejs/node/issues/40702)
+  - Fixed by using `127.0.0.1` instead of `localhost`
+
 ## [1.1.0] - 25.11.2021
 ### Added
 - New `StandAloneServer` class

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ads-server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "TwinCAT ADS server for Node.js (unofficial). Listens for incoming ADS protocol commands and responds.",
   "main": "./dist/ads-server.js",
   "scripts": {

--- a/src/ads-server-router.ts
+++ b/src/ads-server-router.ts
@@ -64,7 +64,7 @@ export class RouterServer extends ServerCore {
    */
   public settings: RouterServerSettings = {
     routerTcpPort: 48898,
-    routerAddress: 'localhost',
+    routerAddress: '127.0.0.1',
     localAddress: '',
     localTcpPort: 0,
     localAmsNetId: '',
@@ -335,6 +335,7 @@ export class RouterServer extends ServerCore {
       socket.setTimeout(this.settings.timeoutDelay);
 
       //Finally, connect
+      console.log(this.settings) 
       try {
         socket.connect({
           port: this.settings.routerTcpPort,

--- a/src/ads-server-router.ts
+++ b/src/ads-server-router.ts
@@ -335,7 +335,6 @@ export class RouterServer extends ServerCore {
       socket.setTimeout(this.settings.timeoutDelay);
 
       //Finally, connect
-      console.log(this.settings) 
       try {
         socket.connect({
           port: this.settings.routerTcpPort,

--- a/src/types/ads-server.ts
+++ b/src/types/ads-server.ts
@@ -56,7 +56,7 @@ export interface StandAloneServerSettings extends ServerCoreSettings {
 export interface RouterServerSettings extends ServerCoreSettings {
   /** Optional: Target ADS router TCP port (default: 48898) */
   routerTcpPort: number,
-  /** Optional: Target ADS router IP address/hostname (default: 'localhost') */
+  /** Optional: Target ADS router IP address/hostname (default: '127.0.0.1') */
   routerAddress: string,
   /** Optional: Local IP address to use, use this to change used network interface if required (default: '' = automatic) */
   localAddress: string,


### PR DESCRIPTION
## [1.1.1] - 13.09.2021
- Bug fix: Connecting to local router failed with ECONNREFUSED error on Node.js version 17 and newer
  - See [https://github.com/nodejs/node/issues/40702](https://github.com/nodejs/node/issues/40702)
  - Fixed by using `127.0.0.1` instead of `localhost`